### PR TITLE
refactor: eliminar paso intermedio a decanatura y limpiar UI

### DIFF
--- a/src/app/plan-trabajo-docente/consolidado/consolidado.component.ts
+++ b/src/app/plan-trabajo-docente/consolidado/consolidado.component.ts
@@ -4,16 +4,12 @@ import { MatSort } from "@angular/material/sort";
 import { MatTableDataSource } from "@angular/material/table";
 import { MODALS, ROLES, VIEWS } from "src/app/models/diccionario";
 import { UserService } from "src/app/services/user.service";
-import {
-  head as _head,
-  cloneDeep as _cloneDeep,
-} from "lodash-es";
+import { cloneDeep as _cloneDeep } from "lodash-es";
 import { Periodo } from "src/app/models/parametros/periodo";
 import { TranslateService } from "@ngx-translate/core";
 import { PopUpManager } from "src/app/managers/popUpManager";
 import { PlanTrabajoDocenteService } from "src/app/services/plan-trabajo-docente.service";
 import { ParametrosService } from "src/app/services/parametros.service";
-import { ProyectoAcademicoService } from "src/app/services/proyecto-academico.service";
 import { RespFormat } from "src/app/models/response-format";
 import { checkContent, checkResponse } from "src/app/utils/verify-response";
 import { EstadoConsolidado } from "src/app/models/plan-trabajo-docente/estado-consolidado";
@@ -100,7 +96,6 @@ export class ConsolidadoComponent implements OnInit, AfterViewInit {
     private popUpManager: PopUpManager,
     private planTrabajoDocenteService: PlanTrabajoDocenteService,
     private parametrosService: ParametrosService,
-    private proyectoAcademicoService: ProyectoAcademicoService,
     private tercerosService: TercerosService,
     private sgaPlanTrabajoDocenteMidService: SgaPlanTrabajoDocenteMidService,
     private gestorDocumentalService: GestorDocumentalService,
@@ -143,6 +138,13 @@ export class ConsolidadoComponent implements OnInit, AfterViewInit {
     this.dataSource.sort = this.sort;
   }
 
+  private configurarDataSource(data: any[] = []) {
+    const dataSource = new MatTableDataSource(data);
+    dataSource.paginator = this.paginator;
+    dataSource.sort = this.sort;
+    return dataSource;
+  }
+
   cargarEventoPTD() {
     this.sgaPlanTrabajoDocenteMidService.get("calendario/eventos").subscribe({
       next: (resp: any) => {
@@ -154,6 +156,8 @@ export class ConsolidadoComponent implements OnInit, AfterViewInit {
             this.cargarCalendarioEventos().then(eventosCalendario => {
               this.calendarEventosPTD = eventosCalendario;
               this.resolverProyectosDesdeCalendario();
+              this.verificarRangoFechas();
+              this.intentarListarConsolidados();
             }).catch(err => console.warn(err));
           }
         }
@@ -196,6 +200,12 @@ export class ConsolidadoComponent implements OnInit, AfterViewInit {
       }
     });
     this.proyectos.opciones = Array.from(proyectosMap.values());
+  }
+
+  private intentarListarConsolidados() {
+    if (this.periodos.select && this.proyectos.select && this.enRangoCalendario) {
+      this.listarConsolidados();
+    }
   }
 
   filtrarPeriodosPorCalendario() {
@@ -419,18 +429,15 @@ export class ConsolidadoComponent implements OnInit, AfterViewInit {
 
   async loadSelects() {
     try {
-      let promesas = [];
-      promesas.push(
+      await Promise.all([
         this.loadPeriodo().then((periodos) => {
           this.periodos.opciones = periodos;
           this._todosLosPeriodos = [...periodos];
-        })
-      );
-      promesas.push(
+        }),
         this.cargarEstadosConsolidado().then((estadosConsolidado) => {
           this.estadosConsolidado.opciones = estadosConsolidado;
-        })
-      );
+        }),
+      ]);
     } catch (error) {
       console.warn(error);
       this.popUpManager.showPopUpGeneric(
@@ -449,19 +456,23 @@ export class ConsolidadoComponent implements OnInit, AfterViewInit {
   onProyectoChange() {
     this.periodos.select = undefined;
     this.periodos.opciones = [];
-    this.dataSource = new MatTableDataSource();
+    this.dataSource = this.configurarDataSource();
     if (this.proyectos.select) {
       this.filtrarPeriodosPorCalendario();
     }
   }
 
   onPeriodoChange() {
-    this.dataSource = new MatTableDataSource();
+    this.dataSource = this.configurarDataSource();
     if (this.periodos.select) {
       this.verificarRangoFechas();
       if (!this.enRangoCalendario) {
-        this.popUpManager.showErrorToast("El periodo seleccionado no se encuentra en el rango de fechas.");
+        if (this.calendarEventosPTD.length > 0) {
+          this.popUpManager.showErrorToast("El periodo seleccionado no se encuentra en el rango de fechas.");
+        }
+        return;
       }
+      this.intentarListarConsolidados();
     }
   }
 
@@ -472,6 +483,7 @@ export class ConsolidadoComponent implements OnInit, AfterViewInit {
       );
       return;
     }
+    this.verificarRangoFechas();
     if (!this.enRangoCalendario) {
       this.popUpManager.showErrorToast("El periodo seleccionado no se encuentra en el rango de fechas.");
       return;
@@ -550,11 +562,11 @@ export class ConsolidadoComponent implements OnInit, AfterViewInit {
                 ConsolidadoJson: consolidado,
               });
             });
-            this.dataSource = new MatTableDataSource(formatedData);
+            this.dataSource = this.configurarDataSource(formatedData);
           },
           (err) => {
             console.warn(err);
-            this.dataSource = new MatTableDataSource();
+            this.dataSource = this.configurarDataSource();
           }
         );
     }
@@ -915,15 +927,25 @@ export class ConsolidadoComponent implements OnInit, AfterViewInit {
         .subscribe(
           (resp) => {
             this.listaPlanesConsolidado = resp.Data.listaIdPlanes;
-            const rawFilePDF = new Uint8Array(
-              atob(resp.Data.pdf)
-                .split("")
-                .map((char) => char.charCodeAt(0))
-            );
-            const urlFilePDF = window.URL.createObjectURL(
-              new Blob([rawFilePDF], { type: "application/pdf" })
-            );
-            this.previewFile(urlFilePDF);
+            const pdfBase64 = resp?.Data?.pdf || "";
+            if (pdfBase64.trim().length > 0) {
+              const rawFilePDF = new Uint8Array(
+                atob(pdfBase64)
+                  .split("")
+                  .map((char) => char.charCodeAt(0))
+              );
+              const urlFilePDF = window.URL.createObjectURL(
+                new Blob([rawFilePDF], { type: "application/pdf" })
+              );
+              this.previewFile(urlFilePDF);
+            } else {
+              this.popUpManager.showPopUpGeneric(
+                "",
+                this.translate.instant("ptd.pdf_solover_excel_imprimir"),
+                MODALS.INFO,
+                false
+              );
+            }
             const rawFileExcel = new Uint8Array(
               atob(resp.Data.excel)
                 .split("")

--- a/src/app/plan-trabajo-docente/revision-consolidado/revision-consolidado.component.html
+++ b/src/app/plan-trabajo-docente/revision-consolidado/revision-consolidado.component.html
@@ -80,12 +80,6 @@
                             <mat-header-cell *matHeaderCellDef mat-sort-header> <b>{{ 'GLOBAL.estado' | translate }}</b> </mat-header-cell>
                             <mat-cell *matCellDef="let row"> {{row.estado}} </mat-cell>
                         </ng-container>
-                        <ng-container matColumnDef="enviar">
-                            <mat-header-cell *matHeaderCellDef> <b>{{ 'GLOBAL.enviar' | translate }}</b> </mat-header-cell>
-                            <mat-cell *matCellDef="let row">
-                                <action-button [rowData]="row" [value]="row.enviar" (valueChanged)="accionEnviar($event)"></action-button>
-                            </mat-cell>
-                        </ng-container>
                         <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
                         <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
                     </mat-table>

--- a/src/app/plan-trabajo-docente/revision-consolidado/revision-consolidado.component.ts
+++ b/src/app/plan-trabajo-docente/revision-consolidado/revision-consolidado.component.ts
@@ -11,7 +11,6 @@ import { EstadoConsolidado } from 'src/app/models/plan-trabajo-docente/estado-co
 import { RespFormat } from 'src/app/models/response-format';
 import { ParametrosService } from 'src/app/services/parametros.service';
 import { PlanTrabajoDocenteService } from 'src/app/services/plan-trabajo-docente.service';
-import { ProyectoAcademicoService } from 'src/app/services/proyecto-academico.service';
 import { TercerosService } from 'src/app/services/terceros.service';
 import { UserService } from 'src/app/services/user.service';
 import { GestorDocumentalService } from 'src/app/services/gestor-documental.service';
@@ -33,31 +32,26 @@ export class RevisionConsolidadoComponent implements OnInit, AfterViewInit {
 
   readonly VIEWS = VIEWS;
   readonly ESTADOS = {
-    DEF: '64d1b9ab7344af1caa53ea59',
     ENV: '64e4c32cd9308025c135db2d',
-    AVA: '64e4c34cd93080396f35db2f',
     APR: '64e4c382d93080d1e835db31',
     N_APR: '64e4c3a5d93080299535db34',
-    ENV_AVA: '64e61208a659b2fca5b0bd6a',
   };
   vista: Symbol;
 
   roles: string[] = [];
 
   isSecDecanatura = false;
-  isDecano = false;
 
   opcionesPermisos: string[] = [
     'ver_gestion_consolidado',
     'editar_gestion_consolidado',
     'enviar_secDecanatura',
-    'aprobar_decanatura',
     'ver_consolidados_decanatura',
   ];
   permisos: { [key: string]: boolean } = {};
 
   dataSource: MatTableDataSource<any>;
-  displayedColumns: string[] = ["proyecto_curricular", "codigo", "fecha_radicado", "periodo_academico", "gestion", "estado", "enviar"];
+  displayedColumns: string[] = ["proyecto_curricular", "codigo", "fecha_radicado", "periodo_academico", "gestion", "estado"];
   @ViewChild(MatPaginator) paginator!: MatPaginator;
   @ViewChild(MatSort) sort!: MatSort;
 
@@ -82,7 +76,6 @@ export class RevisionConsolidadoComponent implements OnInit, AfterViewInit {
     private translate: TranslateService,
     private popUpManager: PopUpManager,
     private parametrosService: ParametrosService,
-    private proyectoAcademicoService: ProyectoAcademicoService,
     private planTrabajoDocenteService: PlanTrabajoDocenteService,
     private tercerosService: TercerosService,
     private gestorDocumentalService: GestorDocumentalService,
@@ -110,7 +103,6 @@ export class RevisionConsolidadoComponent implements OnInit, AfterViewInit {
       const resultados = await firstValueFrom(forkJoin(observables));
       this.permisos = resultados;
       this.isSecDecanatura = !!this.permisos['enviar_secDecanatura'];
-      this.isDecano = !!this.permisos['aprobar_decanatura'];
       console.log("Permisos cargados:", this.permisos);
     });
     this.loadSelects();
@@ -118,8 +110,16 @@ export class RevisionConsolidadoComponent implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit() {
-    this.dataSource.paginator = this.paginator;
-    this.dataSource.sort = this.sort;
+    this.conectarPaginadorYOrdenador();
+  }
+
+  private conectarPaginadorYOrdenador() {
+    if (this.paginator) {
+      this.dataSource.paginator = this.paginator;
+    }
+    if (this.sort) {
+      this.dataSource.sort = this.sort;
+    }
   }
 
   cargarEventoPTD() {
@@ -270,26 +270,6 @@ export class RevisionConsolidadoComponent implements OnInit, AfterViewInit {
     this.revisarConsolidado(event.rowData.ConsolidadoJson, readonly);
   }
 
-  accionEnviar(event: any) {
-    if (!this.permisos['aprobar_decanatura']) {
-      this.popUpManager.showErrorAlert(
-        this.translate.instant('GLOBAL.acceso_denegado')
-      );
-      return;
-    }
-    let putPlan = _cloneDeep(event.rowData.ConsolidadoJson);
-    putPlan.estado_consolidado_id = this.ESTADOS.ENV_AVA;
-    this.planTrabajoDocenteService.put('consolidado_docente/'+putPlan._id, putPlan).subscribe(
-      () => {
-        this.popUpManager.showSuccessAlert(this.translate.instant('ptd.actualizar_consolidado_ok'))
-        this.listarConsolidados();
-      }, err => {
-        console.warn(err);
-        this.popUpManager.showErrorAlert(this.translate.instant('ptd.fallo_actualizar_consolidado'))
-      }
-    );
-  }
-
   loadPeriodo(): Promise<Periodo[]> {
     return new Promise((resolve, reject) => {
       this.parametrosService.get('periodo?query=CodigoAbreviacion:PA&sortby=Id&order=desc&limit=0').subscribe({
@@ -367,6 +347,7 @@ export class RevisionConsolidadoComponent implements OnInit, AfterViewInit {
     this.periodos.select = undefined;
     this.periodos.opciones = [];
     this.dataSource = new MatTableDataSource();
+    this.conectarPaginadorYOrdenador();
     if (this.proyectos.select) {
       this.filtrarPeriodosPorCalendario();
     }
@@ -374,11 +355,15 @@ export class RevisionConsolidadoComponent implements OnInit, AfterViewInit {
 
   onPeriodoChange() {
     this.dataSource = new MatTableDataSource();
+    this.conectarPaginadorYOrdenador();
     if (this.periodos.select) {
       this.verificarRangoFechas();
       if (!this.enRangoCalendario) {
         this.popUpManager.showErrorToast("El periodo seleccionado no se encuentra en el rango de fechas.");
+        return;
       }
+
+      this.listarConsolidados();
     }
   }
 
@@ -404,8 +389,10 @@ export class RevisionConsolidadoComponent implements OnInit, AfterViewInit {
         rawlistarConsolidados = rawlistarConsolidados.filter(consolidado => idEstadosFiltro.includes(consolidado.estado_consolidado_id));
         const formatedData = this.estilizarDatosSegunPermisos(rawlistarConsolidados);
         this.dataSource = new MatTableDataSource(formatedData);
+        this.conectarPaginadorYOrdenador();
       }, (err) => {
         this.dataSource = new MatTableDataSource();
+        this.conectarPaginadorYOrdenador();
         console.warn(err);
       });
     }
@@ -413,10 +400,10 @@ export class RevisionConsolidadoComponent implements OnInit, AfterViewInit {
 
   idEstadosSegunPermisos(): string[] {
     if (this.permisos['enviar_secDecanatura']) {
-      return [this.ESTADOS.ENV, this.ESTADOS.AVA, this.ESTADOS.N_APR, this.ESTADOS.ENV_AVA];
+      return [this.ESTADOS.ENV, this.ESTADOS.APR, this.ESTADOS.N_APR];
     }
-    if (this.permisos['aprobar_decanatura']) {
-      return [this.ESTADOS.ENV_AVA, this.ESTADOS.APR, this.ESTADOS.N_APR];
+    if (this.roles.includes(ROLES.DECANO)) {
+      return [this.ESTADOS.APR];
     }
     return [];
   }
@@ -431,9 +418,6 @@ export class RevisionConsolidadoComponent implements OnInit, AfterViewInit {
       if ((consolidado.estado_consolidado_id === this.ESTADOS.ENV) && this.permisos['enviar_secDecanatura']) {
         opcionGestion = "editar";
       }
-      if ((consolidado.estado_consolidado_id === this.ESTADOS.ENV_AVA) && this.permisos['aprobar_decanatura']) {
-        opcionGestion = "editar";
-      }
       formatedData.push({
         "proyecto_curricular": proyecto ? proyecto.Nombre : "",
         "codigo": proyecto ? proyecto.Codigo : "",
@@ -441,7 +425,6 @@ export class RevisionConsolidadoComponent implements OnInit, AfterViewInit {
         "periodo_academico": periodo ? periodo.Nombre : "",
         "gestion": { value: undefined, type: opcionGestion, disabled: !this.permisos['ver_gestion_consolidado'] },
         "estado": estadoConsolidado ? estadoConsolidado.nombre : consolidado.estado_consolidado_id,
-        "enviar": { value: undefined, type: 'enviar', disabled: !this.permisos['enviar_secDecanatura'] || (consolidado.estado_consolidado_id !== this.ESTADOS.AVA) },
         "ConsolidadoJson": consolidado
       })
     })
@@ -463,7 +446,7 @@ export class RevisionConsolidadoComponent implements OnInit, AfterViewInit {
       QuienResponde: '',
       Rol: this.permisos['enviar_secDecanatura']
         ? 'Secretaria Decanatura'
-        : this.permisos['aprobar_decanatura']
+        : this.roles.includes(ROLES.DECANO)
           ? 'Decanatura'
           : '',
       CumpleNorma: !!consolidado.cumple_normativa,
@@ -475,12 +458,12 @@ export class RevisionConsolidadoComponent implements OnInit, AfterViewInit {
 
     const estadoActualId = consolidado.estado_consolidado_id;
     if (this.isSecDecanatura) {
-      const decisionSec = estadoActualId === this.ESTADOS.N_APR ? this.ESTADOS.N_APR : this.ESTADOS.AVA;
-      if ([this.ESTADOS.AVA, this.ESTADOS.N_APR, this.ESTADOS.ENV_AVA].includes(estadoActualId)) {
+      const decisionSec = estadoActualId === this.ESTADOS.N_APR ? this.ESTADOS.N_APR : this.ESTADOS.APR;
+      if ([this.ESTADOS.ENV, this.ESTADOS.APR, this.ESTADOS.N_APR].includes(estadoActualId)) {
         this.formRevConsolidado.patchValue({ Decision: decisionSec });
       }
     }
-    if (this.isDecano && [this.ESTADOS.APR, this.ESTADOS.N_APR].includes(estadoActualId)) {
+    if (this.roles.includes(ROLES.DECANO) && [this.ESTADOS.APR, this.ESTADOS.N_APR].includes(estadoActualId)) {
       this.formRevConsolidado.patchValue({ Decision: estadoActualId });
     }
 
@@ -494,10 +477,6 @@ export class RevisionConsolidadoComponent implements OnInit, AfterViewInit {
     if (this.isSecDecanatura && respuestaDecanatura?.sec) {
       this.formRevConsolidado.patchValue({ Observaciones: respuestaDecanatura.sec.observacion || '' });
       terceroId = respuestaDecanatura.sec.responsable_id || 0;
-    }
-    if (this.isDecano && respuestaDecanatura?.dec) {
-      this.formRevConsolidado.patchValue({ Observaciones: respuestaDecanatura.dec.observacion || '' });
-      terceroId = respuestaDecanatura.dec.responsable_id || 0;
     }
 
     if (!terceroId) {
@@ -541,14 +520,6 @@ export class RevisionConsolidadoComponent implements OnInit, AfterViewInit {
       putPlan.cumple_normativa = !!this.formRevConsolidado.get('CumpleNorma')?.value;
     }
 
-    if (this.permisos['aprobar_decanatura']) {
-      respuestaDecanatura.dec = {
-        ...respuestaDecanatura.dec,
-        responsable_id: personaId,
-        observacion: this.formRevConsolidado.get('Observaciones')?.value,
-      };
-    }
-
     putPlan.estado_consolidado_id = this.formRevConsolidado.get('Decision')?.value;
     putPlan.aprobado = putPlan.estado_consolidado_id === this.ESTADOS.APR;
     putPlan.respuesta_decanatura = JSON.stringify(respuestaDecanatura);
@@ -566,19 +537,14 @@ export class RevisionConsolidadoComponent implements OnInit, AfterViewInit {
   }
 
   private configurarOpcionesPorPermisos() {
-    if (this.permisos['enviar_secDecanatura']) {
-      this.opcionesDecision = [
-        { id: this.ESTADOS.AVA, nombre: 'Enviar para aprobacion por decanatura' },
-        { id: this.ESTADOS.N_APR, nombre: 'Enviar a coordinacion para su revision' },
-      ];
-      this.formRevConsolidado.get('CumpleNorma')?.enable();
-      return;
-    }
-
     this.opcionesDecision = [
       { id: this.ESTADOS.APR, nombre: 'Aprobar consolidado' },
       { id: this.ESTADOS.N_APR, nombre: 'No aprobar consolidado' },
     ];
+    if (this.isSecDecanatura) {
+      this.formRevConsolidado.get('CumpleNorma')?.enable();
+      return;
+    }
     this.formRevConsolidado.get('CumpleNorma')?.disable();
   }
 

--- a/src/app/plan-trabajo-docente/verificar-ptd/verificar-ptd.component.ts
+++ b/src/app/plan-trabajo-docente/verificar-ptd/verificar-ptd.component.ts
@@ -341,7 +341,7 @@ export class VerificarPtdComponent implements OnInit, AfterViewInit {
       const observacionMasiva = this.translate.instant('ptd.aprobacion_masiva_observacion');
 
       const respAprobacionMasiva: any = await firstValueFrom(
-        this.sgaPlanTrabajoDocenteMidService.put('plan/aprobacion-masiva', {
+        this.sgaPlanTrabajoDocenteMidService.put('plan/aprobacion_masiva', {
           plan_docente_ids: planDocenteIds,
           responsable_id: responsableId,
           observacion: observacionMasiva,


### PR DESCRIPTION
- Se removió la transición intermedia 'enviar_secDecanatura' en revision-consolidado.
- Se eliminó la columna física 'enviar' y la acción accionEnviar del DOM.
- Se restringió la vista de Decanos a modo de consulta histórica.

udistrital/sga_documentacion_inversion#253